### PR TITLE
Replace exec to spawn.

### DIFF
--- a/mecab.js
+++ b/mecab.js
@@ -17,10 +17,18 @@ var buildCommand = function (text, dicdir) {
 };
 
 var execMecab = function (text, callback, dicdir) {
-    cp.exec(buildCommand(text, dicdir), { maxBuffer: 500 * 1024 }, function(err, result) {
-        if (err) { return callback(err); }
-        callback(err, result);
-    });
+  var env = {'LD_LIBRARY_PATH':'/usr/local'};
+  var result = '';
+  var err = '';
+  prs = cp.spawn('/usr/local/bin/mecab', [], {'env':env});
+  prs.stdout.on('data', (data) => { result += data.toString() });
+  prs.stderr.on('data', (data) => { err += data.toString() });
+  prs.on('close', (code) => {
+    if (code !== 0) { return callback(err); }
+    callback(err, result);
+  });
+  prs.stdin.write(new Buffer(text, 'utf8'));
+  prs.stdin.end();
 };
 
 var parseFunctions = {


### PR DESCRIPTION
exec를  spawn으로 교체 완료했습니다.

200kb 이상의 텍스트가 무리없이 처리되는 것을 확인했습니다.
단, 한 줄에 17000 byte 가 넘어가면 mecab 자체의 버퍼가 넘치는 현상이 발생합니다.
이는 -b 옵션으로 증가시킬 수 있으니 참고바랍니다.